### PR TITLE
Adds support for Dependency Injection using dagger 2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,10 @@ dependencies {
     implementation configs.appcompat
     implementation configs.constraintlayout
 
+    // DI
+    implementation configs.dagger_core
+    kapt configs.dagger_compiler
+
     // RxJava
     implementation configs.rxJava
     implementation configs.rxAndroid

--- a/app/src/androidTest/java/io/github/farhad/popcorn/remote/ApiServiceTest.kt
+++ b/app/src/androidTest/java/io/github/farhad/popcorn/remote/ApiServiceTest.kt
@@ -41,7 +41,7 @@ class ApiServiceTest {
         mockWebServer = MockWebServer()
         val httpUrl = mockWebServer.url(BASE_URL)
 
-        val apiKeyInterceptor = ApiKeyInterceptor(TEST_API_KEY)
+        val apiKeyInterceptor = ApiKeyInterceptor()
         val okHttpClient = MovieApiHttpClient.create(apiKeyInterceptor)
         val gsonFactory = GsonFactory()
         val retrofit = NetworkingConfig(httpUrl.toString(), okHttpClient, gsonFactory).retrofit()

--- a/app/src/androidTest/java/io/github/farhad/popcorn/remote/NetworkingConfig.kt
+++ b/app/src/androidTest/java/io/github/farhad/popcorn/remote/NetworkingConfig.kt
@@ -1,10 +1,10 @@
-package io.github.farhad.popcorn.data.remote.api
+package io.github.farhad.popcorn.remote
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import io.github.farhad.popcorn.data.remote.api.DateTypeConverter
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
@@ -53,17 +53,3 @@ class MovieApiHttpClient {
     }
 }
 
-class ApiKeyInterceptor(private val apiKey: String) : Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
-        var request = chain.request()
-
-        val url = request.url()
-            .newBuilder()
-            .addQueryParameter("api_key", apiKey)
-            .build()
-
-        request = request.newBuilder().url(url).build()
-
-        return chain.proceed(request)
-    }
-}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
+            android:name=".PopcornApp"
             tools:ignore="AllowBackup,GoogleAppIndexingWarning">
 
         <activity android:name=".ui.home.HomeActivity">

--- a/app/src/main/java/io/github/farhad/popcorn/PopcornApp.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/PopcornApp.kt
@@ -1,0 +1,17 @@
+package io.github.farhad.popcorn
+
+import android.app.Application
+import io.github.farhad.popcorn.di.AppComponent
+import io.github.farhad.popcorn.di.DaggerAppComponent
+import io.github.farhad.popcorn.di.HasAppComponent
+
+class PopcornApp : Application(), HasAppComponent {
+
+    override fun onCreate() {
+        super.onCreate()
+
+    }
+
+    override val appComponent: AppComponent
+        get() = DaggerAppComponent.builder().application(this).build()
+}

--- a/app/src/main/java/io/github/farhad/popcorn/data/db/LocalDataSource.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/data/db/LocalDataSource.kt
@@ -7,8 +7,9 @@ import io.github.farhad.popcorn.domain.transformer.Transformer
 import io.reactivex.Completable
 import io.reactivex.Observable
 import org.threeten.bp.Instant
+import javax.inject.Inject
 
-class LocalDataSource constructor(private val database: MovieDatabase) {
+class LocalDataSource @Inject constructor(val database: MovieDatabase) {
 
     fun getUpcomingMovies(
         updatedAfter: Instant,

--- a/app/src/main/java/io/github/farhad/popcorn/data/remote/RemoteDataSource.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/data/remote/RemoteDataSource.kt
@@ -6,11 +6,9 @@ import io.github.farhad.popcorn.data.entity.RoleEntity
 import io.github.farhad.popcorn.data.remote.api.ApiService
 import io.github.farhad.popcorn.domain.transformer.Transformer
 import io.reactivex.Observable
+import javax.inject.Inject
 
-/**
- * [apiService] should be injected here
- */
-class RemoteDataSource constructor(private val apiService: ApiService) {
+class RemoteDataSource @Inject constructor(val apiService: ApiService) {
 
     fun getUpcomingMovies(page: Int = 1, transformer: Transformer<List<MovieEntity>?>): Observable<List<MovieEntity>?> {
         return apiService.getUpcomingMovies(page)

--- a/app/src/main/java/io/github/farhad/popcorn/data/remote/api/ApiKeyInterceptor.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/data/remote/api/ApiKeyInterceptor.kt
@@ -1,0 +1,27 @@
+package io.github.farhad.popcorn.data.remote.api
+
+import io.github.farhad.popcorn.di.NamedString
+import io.github.farhad.popcorn.di.StringType
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class ApiKeyInterceptor : Interceptor {
+
+    @Inject
+    @field:NamedString(StringType.API_KEY)
+    lateinit var apiKey: String
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        var request = chain.request()
+
+        val url = request.url()
+            .newBuilder()
+            .addQueryParameter("api_key", apiKey)
+            .build()
+
+        request = request.newBuilder().url(url).build()
+
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/io/github/farhad/popcorn/data/repository/AppRepository.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/data/repository/AppRepository.kt
@@ -10,16 +10,13 @@ import io.github.farhad.popcorn.domain.repository.Repository
 import io.github.farhad.popcorn.domain.transformer.IOTransformer
 import io.reactivex.Observable
 import org.threeten.bp.Instant
+import javax.inject.Inject
 
-/**
- * all the repository instances should be injected here
- */
-class AppRepository constructor(
-    private val remoteDataSource: RemoteDataSource,
-    private val localDataSource: LocalDataSource,
-    private val transformer: EntityTransformer
+class AppRepository @Inject constructor(
+    val remoteDataSource: RemoteDataSource,
+    val localDataSource: LocalDataSource,
+    val transformer: EntityTransformer
 ) : Repository {
-
 
     // initializing updatedAts to beginning of timestamp (1970-01-01)
     private var lastTrendingUpdatedAt: Instant = Instant.ofEpochMilli(0)

--- a/app/src/main/java/io/github/farhad/popcorn/data/repository/EntityTransformer.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/data/repository/EntityTransformer.kt
@@ -10,7 +10,7 @@ import io.reactivex.Observable
 import io.reactivex.ObservableSource
 import io.reactivex.ObservableTransformer
 
-sealed class EntityTransformer {
+class EntityTransformer {
 
     inner class MovieTransformer : ObservableTransformer<List<MovieEntity>?, List<Movie>?> {
 

--- a/app/src/main/java/io/github/farhad/popcorn/di/AppComponent.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/di/AppComponent.kt
@@ -1,0 +1,25 @@
+package io.github.farhad.popcorn.di
+
+import dagger.BindsInstance
+import dagger.Component
+import io.github.farhad.popcorn.PopcornApp
+import io.github.farhad.popcorn.data.remote.api.ApiKeyInterceptor
+
+@ApplicationScope
+@Component(
+    modules = [
+        DbModule::class,
+        NetworkingModule::class,
+        DataSourceModule::class]
+)
+interface AppComponent {
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun application(app: PopcornApp): Builder
+
+        fun build(): AppComponent
+    }
+
+    fun inject(apiKeyInterceptor: ApiKeyInterceptor)
+}

--- a/app/src/main/java/io/github/farhad/popcorn/di/ApplicationScope.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/di/ApplicationScope.kt
@@ -1,0 +1,8 @@
+package io.github.farhad.popcorn.di
+
+import javax.inject.Scope
+
+@Scope
+@MustBeDocumented
+@Retention(value = AnnotationRetention.RUNTIME)
+annotation class ApplicationScope

--- a/app/src/main/java/io/github/farhad/popcorn/di/DataSourceModule.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/di/DataSourceModule.kt
@@ -1,0 +1,25 @@
+package io.github.farhad.popcorn.di
+
+import dagger.Module
+import dagger.Provides
+import io.github.farhad.popcorn.data.db.LocalDataSource
+import io.github.farhad.popcorn.data.db.MovieDatabase
+import io.github.farhad.popcorn.data.remote.RemoteDataSource
+import io.github.farhad.popcorn.data.remote.api.ApiService
+import io.github.farhad.popcorn.data.repository.EntityTransformer
+
+@Module
+class DataSourceModule {
+
+    @Provides
+    @ApplicationScope
+    fun provideRemoteDataSource(apiService: ApiService): RemoteDataSource = RemoteDataSource(apiService)
+
+    @Provides
+    @ApplicationScope
+    fun provideLocalDataSource(database: MovieDatabase): LocalDataSource = LocalDataSource(database)
+
+    @Provides
+    @ApplicationScope
+    fun provideEntityTransformer(): EntityTransformer = EntityTransformer()
+}

--- a/app/src/main/java/io/github/farhad/popcorn/di/DbModule.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/di/DbModule.kt
@@ -1,0 +1,26 @@
+package io.github.farhad.popcorn.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import io.github.farhad.popcorn.data.db.MovieDatabase
+import io.github.farhad.popcorn.data.db.dao.MovieEntityDao
+import io.github.farhad.popcorn.data.db.dao.PerformerEntityDao
+import io.github.farhad.popcorn.data.db.dao.RoleEntityDao
+
+@Module
+class DbModule {
+
+    @Provides
+    @ApplicationScope
+    fun provideDatabase(context: Context): MovieDatabase = MovieDatabase.create(context)
+
+    @Provides
+    fun provideMovieEntityDao(database: MovieDatabase): MovieEntityDao = database.getMovieEntityDao()
+
+    @Provides
+    fun providePerformerEntityDao(database: MovieDatabase): PerformerEntityDao = database.getPerformerEntityDao()
+
+    @Provides
+    fun provideRoleEntityDao(database: MovieDatabase): RoleEntityDao = database.getRoleEntityDao()
+}

--- a/app/src/main/java/io/github/farhad/popcorn/di/HasAppComponent.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/di/HasAppComponent.kt
@@ -1,0 +1,5 @@
+package io.github.farhad.popcorn.di
+
+interface HasAppComponent {
+    val appComponent: AppComponent
+}

--- a/app/src/main/java/io/github/farhad/popcorn/di/NamedString.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/di/NamedString.kt
@@ -1,0 +1,13 @@
+package io.github.farhad.popcorn.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+annotation class NamedString(val type: StringType)
+
+enum class StringType {
+    API_KEY,
+    BASE_URL
+}

--- a/app/src/main/java/io/github/farhad/popcorn/di/NetworkingModule.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/di/NetworkingModule.kt
@@ -1,0 +1,81 @@
+package io.github.farhad.popcorn.di
+
+import com.google.gson.GsonBuilder
+import dagger.Module
+import dagger.Provides
+import io.github.farhad.popcorn.data.remote.api.ApiKeyInterceptor
+import io.github.farhad.popcorn.data.remote.api.ApiService
+import io.github.farhad.popcorn.data.remote.api.DateTypeConverter
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import retrofit2.Converter
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+@Module
+class NetworkingModule {
+
+    @Provides
+    @ApplicationScope
+    fun provideApiService(retrofit: Retrofit): ApiService {
+        return retrofit.create(ApiService::class.java)
+    }
+
+    @Provides
+    fun provideOkHttpClient(interceptors: Array<Interceptor>): OkHttpClient {
+
+        val okHttpClient = OkHttpClient.Builder()
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
+
+        interceptors.forEach { okHttpClient.addInterceptor(it) }
+
+        return okHttpClient.build()
+    }
+
+    @Provides
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        converterFactory: Converter.Factory,
+        @NamedString(StringType.BASE_URL) baseUrl: String
+    ): Retrofit {
+
+        return Retrofit.Builder()
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+            .addConverterFactory(converterFactory)
+            .baseUrl(baseUrl)
+            .client(okHttpClient)
+            .build()
+    }
+
+    @Provides
+    fun provideGsonConverterFactory(): Converter.Factory {
+        val gson = GsonBuilder()
+            .registerTypeAdapter(Date::class.java, DateTypeConverter())
+            .serializeNulls()
+            .create()
+
+        return GsonConverterFactory.create(gson)
+    }
+
+    @Provides
+    fun provideInterceptors(): Array<Interceptor> {
+        return arrayOf(ApiKeyInterceptor())
+    }
+
+    @Provides
+    @NamedString(StringType.API_KEY)
+    fun provideApiKeyString(): String {
+        return ""
+    }
+
+    @Provides
+    @NamedString(StringType.BASE_URL)
+    fun provideBaseUrl(): String {
+        return ""
+    }
+}


### PR DESCRIPTION
- Adds dagger 2 dependencies
- Adds dagger modules
- Adds dagger component
- Adds PopcornApp class
- Changes AppRepository, DataSource and EntityTransformer to accepted injected fields
- Moves NetworkingConfig to androidTest package
- Makes a temporary fix in ApiServiceTest