### PR TITLE
Fixes dagger issues in androidTests after adding activity, fragment and ViewModel injection

### DIFF
--- a/app/src/androidTest/java/io/github/farhad/popcorn/testing/TestApp.kt
+++ b/app/src/androidTest/java/io/github/farhad/popcorn/testing/TestApp.kt
@@ -5,5 +5,5 @@ import io.github.farhad.popcorn.di.AppComponent
 
 class TestApp : PopcornApp() {
 
-    override val appComponent: AppComponent = DaggerTestAppComponent.builder().application(this).build()
+    override var appComponent: AppComponent = DaggerTestAppComponent.builder().application(this).build()
 }

--- a/app/src/androidTest/java/io/github/farhad/popcorn/testing/TestAppComponent.kt
+++ b/app/src/androidTest/java/io/github/farhad/popcorn/testing/TestAppComponent.kt
@@ -2,16 +2,19 @@ package io.github.farhad.popcorn.testing
 
 import dagger.BindsInstance
 import dagger.Component
+import dagger.android.AndroidInjectionModule
 import io.github.farhad.popcorn.PopcornApp
-import io.github.farhad.popcorn.di.AppComponent
-import io.github.farhad.popcorn.di.ApplicationScope
-import io.github.farhad.popcorn.di.DataSourceModule
-import io.github.farhad.popcorn.di.DbModule
+import io.github.farhad.popcorn.di.*
 import io.github.farhad.popcorn.remote.ApiServiceTest
 
 @ApplicationScope
 @Component(
     modules = [
+        AndroidInjectionModule::class,
+        ActivityModule::class,
+        FragmentModule::class,
+        AppModule::class,
+        ViewModelModule::class,
         DbModule::class,
         TestNetworkingModule::class,
         DataSourceModule::class]

--- a/app/src/main/java/io/github/farhad/popcorn/PopcornApp.kt
+++ b/app/src/main/java/io/github/farhad/popcorn/PopcornApp.kt
@@ -30,8 +30,7 @@ open class PopcornApp : Application(), HasAppComponent, HasActivityInjector, Has
     override fun activityInjector(): AndroidInjector<Activity> = activityDispatchingAndroidInjector
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = fragmentDispatchingAndroidInjector
 
-    final override lateinit var appComponent: AppComponent
-        private set
+    override lateinit var appComponent: AppComponent
 
     override fun onCreate() {
         super.onCreate()


### PR DESCRIPTION
Fixes dagger issues in androidTests after adding activity, fragment and ViewModel injection